### PR TITLE
fix(cm): make remote part optional in load command

### DIFF
--- a/cmd/cm/load.go
+++ b/cmd/cm/load.go
@@ -1,51 +1,30 @@
 package main
 
 import (
-	"strings"
-
 	cm "github.com/lerenn/cm/pkg/cm"
 	"github.com/spf13/cobra"
 )
 
 func createLoadCmd() *cobra.Command {
 	loadCmd := &cobra.Command{
-		Use:   "load <remote-source:branch-name> [--ide <ide-name>]",
+		Use:   "load [remote:]<branch-name> [--ide <ide-name>]",
 		Short: "Load a branch from a remote source",
 		Long: `Load a branch from a remote source and create a worktree.
 
+The remote part is optional and defaults to "origin" if not specified.
+
 Examples:
-  cm load origin:feature-branch
-  cm load upstream:main
-  cm load origin:feature-branch --ide vscode`,
+  cm load feature-branch          # Uses origin:feature-branch
+  cm load origin:feature-branch   # Explicitly specify remote
+  cm load upstream:main           # Use different remote
+  cm load feature-branch --ide vscode`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			cfg := loadConfig()
 			cmManager := cm.NewCM(cfg)
 			cmManager.SetVerbose(verbose)
 
-			// Parse remote source and branch name
-			parts := strings.SplitN(args[0], ":", 2)
-			if len(parts) != 2 {
-				return cm.ErrInvalidArgumentFormat
-			}
-
-			remoteSource := strings.TrimSpace(parts[0])
-			branchName := strings.TrimSpace(parts[1])
-
-			if remoteSource == "" {
-				return cm.ErrEmptyRemoteSource
-			}
-
-			if branchName == "" {
-				return cm.ErrEmptyBranchName
-			}
-
-			// Check if branch name contains colon (invalid)
-			if strings.Contains(branchName, ":") {
-				return cm.ErrBranchNameContainsColon
-			}
-
-			// Load the worktree
+			// Let CM package handle all parsing and validation
 			return cmManager.LoadWorktree(args[0])
 		},
 	}

--- a/test/load_repo_test.go
+++ b/test/load_repo_test.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lerenn/cm/pkg/cm"
+	"github.com/lerenn/cm/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadWorktree loads a worktree using the CM instance
+func loadWorktree(t *testing.T, setup *TestSetup, branchArg string) error {
+	t.Helper()
+
+	cmInstance := cm.NewCM(&config.Config{
+		BasePath:   setup.CmPath,
+		StatusFile: setup.StatusPath,
+	})
+
+	// Safely change to repo directory and load worktree
+	restore := safeChdir(t, setup.RepoPath)
+	defer restore()
+
+	return cmInstance.LoadWorktree(branchArg)
+}
+
+func TestLoadWorktreeWithOptionalRemote(t *testing.T) {
+	setup := setupTestEnvironment(t)
+	defer cleanupTestEnvironment(t, setup)
+
+	// Create a test Git repository
+	createTestGitRepo(t, setup.RepoPath)
+
+	// Safely change to repo directory for setup
+	restore := safeChdir(t, setup.RepoPath)
+	defer restore()
+
+	// Add origin remote
+	require.NoError(t, os.WriteFile(".git/config", []byte(`[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+[remote "origin"]
+	url = https://github.com/testuser/testrepo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+	remote = origin
+	merge = refs/heads/main
+`), 0644))
+
+	// Test 1: Load branch without specifying remote (should default to origin)
+	t.Run("LoadBranchWithoutRemote", func(t *testing.T) {
+		err := loadWorktree(t, setup, "feature/test-branch")
+		// This will fail because the remote doesn't exist in the test environment
+		// but it tests that the parsing works correctly
+		assert.Error(t, err)
+		// The error should be about the remote not being found, not about parsing
+		assert.NotContains(t, err.Error(), "invalid argument format")
+	})
+
+	// Test 2: Load branch with explicit remote
+	t.Run("LoadBranchWithExplicitRemote", func(t *testing.T) {
+		err := loadWorktree(t, setup, "origin:feature/test-branch")
+		// This will fail because the remote doesn't exist in the test environment
+		// but it tests that the parsing works correctly
+		assert.Error(t, err)
+		// The error should be about the remote not being found, not about parsing
+		assert.NotContains(t, err.Error(), "invalid argument format")
+	})
+
+	// Test 3: Error case - invalid format
+	t.Run("LoadInvalidFormat", func(t *testing.T) {
+		err := loadWorktree(t, setup, "invalid:branch:format")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "branch name contains invalid character")
+	})
+
+	// Test 4: Error case - empty argument
+	t.Run("LoadEmptyArgument", func(t *testing.T) {
+		err := loadWorktree(t, setup, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "argument cannot be empty")
+	})
+}
+
+func TestLoadWorktreeWithNewRemote(t *testing.T) {
+	setup := setupTestEnvironment(t)
+	defer cleanupTestEnvironment(t, setup)
+
+	// Create a test Git repository
+	createTestGitRepo(t, setup.RepoPath)
+
+	// Safely change to repo directory for setup
+	restore := safeChdir(t, setup.RepoPath)
+	defer restore()
+
+	// Add origin remote
+	require.NoError(t, os.WriteFile(".git/config", []byte(`[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+[remote "origin"]
+	url = https://github.com/testuser/testrepo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+	remote = origin
+	merge = refs/heads/main
+`), 0644))
+
+	// Test loading from a new remote (this will fail in real scenario but tests the parsing)
+	t.Run("LoadFromNewRemote", func(t *testing.T) {
+		err := loadWorktree(t, setup, "otheruser:feature-branch")
+		// This will fail because the remote doesn't exist, but it tests that the parsing works
+		assert.Error(t, err)
+		// The error should be about the remote not being found, not about parsing
+		assert.NotContains(t, err.Error(), "invalid argument format")
+	})
+}


### PR DESCRIPTION
- Updated CLI to accept [remote:]branch-name format where remote defaults to origin
- Modified load command usage from <remote-source:branch-name> to [remote:]<branch-name>
- Updated help text to explain optional remote functionality with examples
- Removed parsing logic from CLI layer, moved all business logic to CM package
- Added comprehensive end-to-end tests for optional remote functionality
- Tests cover both formats: with and without remote specification
- Tests error cases like invalid format and empty arguments
- All existing unit tests continue to pass
- CLI validation works correctly for error cases
- Help output clearly shows the new optional format