### PR TITLE
fix(cm): restore -i and --ide flags functionality for load and create…

### DIFF
--- a/cmd/cm/create.go
+++ b/cmd/cm/create.go
@@ -23,7 +23,7 @@ Examples:
 
 			var opts []cm.CreateWorkTreeOpts
 			if ideName != "" {
-				opts = append(opts, cm.CreateWorkTreeOpts{})
+				opts = append(opts, cm.CreateWorkTreeOpts{IDEName: ideName})
 			}
 
 			return cmManager.CreateWorkTree(args[0], opts...)

--- a/cmd/cm/load.go
+++ b/cmd/cm/load.go
@@ -45,8 +45,14 @@ Examples:
 				return cm.ErrBranchNameContainsColon
 			}
 
+			// Prepare options for LoadWorktree
+			var opts []cm.LoadWorktreeOpts
+			if ideName != "" {
+				opts = append(opts, cm.LoadWorktreeOpts{IDEName: ideName})
+			}
+
 			// Load the worktree
-			return cmManager.LoadWorktree(args[0])
+			return cmManager.LoadWorktree(args[0], opts...)
 		},
 	}
 


### PR DESCRIPTION
… commands

- Fixed load command to properly pass IDE name to LoadWorktree method using LoadWorktreeOpts
- Fixed create command to properly pass IDE name to CreateWorkTree method using CreateWorkTreeOpts
- Both commands now correctly handle variadic option parameters
- Verified all tests pass including unit, integration, and end-to-end tests
- Confirmed CLI help documentation shows proper flag usage
- Manual testing confirms IDE functionality works as expected