### PR TITLE
feat(cm): restore --from-issue flag for worktree create command

### DIFF
--- a/cmd/cm/worktree/create.go
+++ b/cmd/cm/worktree/create.go
@@ -10,43 +10,85 @@ import (
 func createCreateCmd() *cobra.Command {
 	var ideName string
 	var force bool
+	var fromIssue string
 
 	createCmd := &cobra.Command{
-		Use:   "create <branch> [--ide <ide-name>]",
-		Short: "Create a worktree for the specified branch",
-		Long: `Create a worktree for the specified branch in the current repository or workspace.
+		Use:   "create [branch] [--from-issue <issue-reference>] [--ide <ide-name>]",
+		Short: "Create a worktree for the specified branch or from a GitHub issue",
+		Long:  getCreateCommandLongDescription(),
+		Args:  createCreateCmdArgsValidator(&fromIssue),
+		RunE:  createCreateCmdRunE(&ideName, &force, &fromIssue),
+	}
+
+	// Add flags
+	createCmd.Flags().StringVarP(&ideName, "ide", "i", "", "Open in specified IDE after creation")
+	createCmd.Flags().BoolVarP(&force, "force", "f", false, "Force creation without prompts")
+	createCmd.Flags().StringVar(&fromIssue, "from-issue", "", 
+		"Create worktree from GitHub issue (URL, number, or owner/repo#issue format)")
+
+	return createCmd
+}
+
+// getCreateCommandLongDescription returns the long description for the create command.
+func getCreateCommandLongDescription() string {
+	return `Create a worktree for the specified branch in the current repository or workspace.
+When using --from-issue, the branch name becomes optional and will be inferred from the issue title.
+
+Issue Reference Formats:
+  - GitHub issue URL: https://github.com/owner/repo/issues/123
+  - Issue number (requires remote origin to be GitHub): 123
+  - Owner/repo#issue format: owner/repo#123
 
 Examples:
   cm worktree create feature-branch
   cm wt create feature-branch --ide vscode
-  cm w create feature-branch --ide cursor`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if err := config.CheckInitialization(); err != nil {
-				return err
-			}
+  cm w create feature-branch --ide cursor
+  cm worktree create --from-issue https://github.com/owner/repo/issues/123
+  cm worktree create custom-branch --from-issue 456
+  cm worktree create --from-issue owner/repo#789 --ide cursor`
+}
 
-			cfg, err := config.LoadConfig()
-			if err != nil {
-				return err
-			}
-			cmManager := cm.NewCM(cfg)
-			cmManager.SetVerbose(config.Verbose)
-
-			var opts cm.CreateWorkTreeOpts
-			if ideName != "" {
-				opts.IDEName = ideName
-			}
-			opts.Force = force
-
-			return cmManager.CreateWorkTree(args[0], opts)
-		},
+// createCreateCmdArgsValidator creates the argument validator for the create command.
+func createCreateCmdArgsValidator(fromIssue *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// If --from-issue is provided, branch name is optional
+		if *fromIssue != "" {
+			return cobra.MaximumNArgs(1)(cmd, args)
+		}
+		// Otherwise, branch name is required
+		return cobra.ExactArgs(1)(cmd, args)
 	}
+}
 
-	// Add IDE flag to create command
-	createCmd.Flags().StringVarP(&ideName, "ide", "i", "", "Open in specified IDE after creation")
-	// Add force flag to create command
-	createCmd.Flags().BoolVarP(&force, "force", "f", false, "Force creation without prompts")
+// createCreateCmdRunE creates the RunE function for the create command.
+func createCreateCmdRunE(ideName *string, force *bool, fromIssue *string) func(*cobra.Command, []string) error {
+	return func(_ *cobra.Command, args []string) error {
+		if err := config.CheckInitialization(); err != nil {
+			return err
+		}
 
-	return createCmd
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			return err
+		}
+		cmManager := cm.NewCM(cfg)
+		cmManager.SetVerbose(config.Verbose)
+
+		// Determine branch name
+		var branchName string
+		if len(args) > 0 {
+			branchName = args[0]
+		}
+
+		var opts cm.CreateWorkTreeOpts
+		if *ideName != "" {
+			opts.IDEName = *ideName
+		}
+		if *fromIssue != "" {
+			opts.IssueRef = *fromIssue
+		}
+		opts.Force = *force
+
+		return cmManager.CreateWorkTree(branchName, opts)
+	}
 }


### PR DESCRIPTION
- Added --from-issue flag to cm worktree create command
- Updated command usage to show optional branch parameter when using --from-issue
- Enhanced help text with issue reference formats and examples
- Implemented custom argument validation for optional branch name
- Refactored code to meet linting requirements (function length and line length)
- Fixed type errors in function signatures
- All tests pass: unit, integration, and end-to-end tests
- Issue reference formats supported: GitHub URLs, issue numbers, owner/repo#issue format