### PR TITLE
fix(git): implement reference conflict detection for branch creation

### DIFF
--- a/pkg/git/errors.go
+++ b/pkg/git/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrRemoteAddFailed        = errors.New("failed to add remote")
 	ErrFetchFailed            = errors.New("failed to fetch from remote")
 	ErrBranchNotFoundOnRemote = errors.New("branch not found on remote")
+	ErrReferenceConflict      = errors.New("reference conflict: cannot create branch due to existing reference")
 )

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -41,6 +41,9 @@ type Git interface {
 	// CreateBranchFrom creates a new branch from a specific branch.
 	CreateBranchFrom(params CreateBranchFromParams) error
 
+	// CheckReferenceConflict checks if creating a branch would conflict with existing references.
+	CheckReferenceConflict(repoPath, branch string) error
+
 	// WorktreeExists checks if a worktree exists for the specified branch.
 	WorktreeExists(repoPath, branch string) (bool, error)
 
@@ -278,6 +281,32 @@ func (g *realGit) CreateBranchFrom(params CreateBranchFromParams) error {
 			err, params.NewBranch, params.FromBranch, string(output))
 	}
 
+	return nil
+}
+
+// CheckReferenceConflict checks if creating a branch would conflict with existing references.
+func (g *realGit) CheckReferenceConflict(repoPath, branch string) error {
+	// Check if any parent reference exists that would conflict
+	parts := strings.Split(branch, "/")
+	for i := 1; i < len(parts); i++ {
+		parentRef := strings.Join(parts[:i], "/")
+
+		// Check if parent reference exists as a branch
+		cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+parentRef)
+		cmd.Dir = repoPath
+		if err := cmd.Run(); err == nil {
+			return fmt.Errorf("%w: cannot create branch '%s': reference 'refs/heads/%s' already exists",
+				ErrReferenceConflict, branch, parentRef)
+		}
+
+		// Also check tags
+		cmd = exec.Command("git", "show-ref", "--verify", "--quiet", "refs/tags/"+parentRef)
+		cmd.Dir = repoPath
+		if err := cmd.Run(); err == nil {
+			return fmt.Errorf("%w: cannot create branch '%s': tag 'refs/tags/%s' already exists",
+				ErrReferenceConflict, branch, parentRef)
+		}
+	}
 	return nil
 }
 

--- a/pkg/git/mockgit.gen.go
+++ b/pkg/git/mockgit.gen.go
@@ -102,6 +102,20 @@ func (mr *MockGitMockRecorder) BranchExistsOnRemote(params any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BranchExistsOnRemote", reflect.TypeOf((*MockGit)(nil).BranchExistsOnRemote), params)
 }
 
+// CheckReferenceConflict mocks base method.
+func (m *MockGit) CheckReferenceConflict(repoPath, branch string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckReferenceConflict", repoPath, branch)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckReferenceConflict indicates an expected call of CheckReferenceConflict.
+func (mr *MockGitMockRecorder) CheckReferenceConflict(repoPath, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckReferenceConflict", reflect.TypeOf((*MockGit)(nil).CheckReferenceConflict), repoPath, branch)
+}
+
 // Clone mocks base method.
 func (m *MockGit) Clone(params CloneParams) error {
 	m.ctrl.T.Helper()

--- a/pkg/git/reference_conflict_test.go
+++ b/pkg/git/reference_conflict_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package git
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckReferenceConflict(t *testing.T) {
+	git := NewGit()
+
+	t.Run("no conflict for simple branch name", func(t *testing.T) {
+		tempDir := setupRefConflictTestRepo(t)
+		err := git.CheckReferenceConflict(tempDir, "feature-branch")
+		assert.NoError(t, err)
+	})
+
+	t.Run("no conflict for nested branch name without existing parent", func(t *testing.T) {
+		tempDir := setupRefConflictTestRepo(t)
+		err := git.CheckReferenceConflict(tempDir, "feature/new-feature")
+		assert.NoError(t, err)
+	})
+
+	t.Run("conflict when parent branch exists", func(t *testing.T) {
+		tempDir := setupRefConflictTestRepo(t)
+
+		// Create a branch called "feat"
+		cmd := exec.Command("git", "branch", "feat")
+		cmd.Dir = tempDir
+		require.NoError(t, cmd.Run())
+
+		// Try to create a branch called "feat/test" - should conflict
+		err := git.CheckReferenceConflict(tempDir, "feat/test")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot create branch 'feat/test': reference 'refs/heads/feat' already exists")
+	})
+
+	t.Run("conflict when parent tag exists", func(t *testing.T) {
+		tempDir := setupRefConflictTestRepo(t)
+
+		// Create a tag called "feature"
+		cmd := exec.Command("git", "tag", "feature")
+		cmd.Dir = tempDir
+		require.NoError(t, cmd.Run())
+
+		// Try to create a branch called "feature/branch" - should conflict
+		err := git.CheckReferenceConflict(tempDir, "feature/branch")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot create branch 'feature/branch': tag 'refs/tags/feature' already exists")
+	})
+
+	t.Run("no conflict for deeply nested branch without conflicts", func(t *testing.T) {
+		tempDir := setupRefConflictTestRepo(t)
+		err := git.CheckReferenceConflict(tempDir, "feature/subfeature/implementation")
+		assert.NoError(t, err)
+	})
+
+	t.Run("conflict with deeply nested existing reference", func(t *testing.T) {
+		tempDir := setupRefConflictTestRepo(t)
+
+		// Create a branch called "feature/subfeature"
+		cmd := exec.Command("git", "branch", "feature/subfeature")
+		cmd.Dir = tempDir
+		require.NoError(t, cmd.Run())
+
+		// Try to create a branch called "feature/subfeature/implementation" - should conflict
+		err := git.CheckReferenceConflict(tempDir, "feature/subfeature/implementation")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot create branch 'feature/subfeature/implementation': reference 'refs/heads/feature/subfeature' already exists")
+	})
+}
+
+// setupRefConflictTestRepo creates a temporary Git repository for testing
+func setupRefConflictTestRepo(t *testing.T) string {
+	// Create a temporary directory for the test
+	tempDir, err := os.MkdirTemp("", "git-ref-conflict-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	// Initialize a Git repository
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tempDir
+	require.NoError(t, cmd.Run())
+
+	// Configure Git user (required for commits)
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = tempDir
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.Command("git", "config", "user.email", "test@example.com")
+	cmd.Dir = tempDir
+	require.NoError(t, cmd.Run())
+
+	// Create an initial commit
+	cmd = exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit")
+	cmd.Dir = tempDir
+	require.NoError(t, cmd.Run())
+
+	return tempDir
+}

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -249,6 +249,11 @@ func (w *realWorktree) ValidateDeletion(params ValidateDeletionParams) error {
 
 // EnsureBranchExists ensures the specified branch exists, creating it if necessary.
 func (w *realWorktree) EnsureBranchExists(repoPath, branch string) error {
+	// First check for reference conflicts
+	if err := w.git.CheckReferenceConflict(repoPath, branch); err != nil {
+		return err
+	}
+
 	branchExists, err := w.git.BranchExists(repoPath, branch)
 	if err != nil {
 		return fmt.Errorf("failed to check if branch exists: %w", err)

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -98,6 +98,7 @@ func TestWorktree_Create_Success(t *testing.T) {
 	mockFS.EXPECT().Exists(params.WorktreePath).Return(false, nil)
 	mockStatus.EXPECT().GetWorktree(params.RepoURL, params.Branch).Return(nil, errors.New("not found"))
 	mockFS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil)
+	mockGit.EXPECT().CheckReferenceConflict(params.RepoPath, params.Branch).Return(nil)
 	mockGit.EXPECT().BranchExists(params.RepoPath, params.Branch).Return(true, nil)
 	mockFS.EXPECT().MkdirAll(params.WorktreePath, gomock.Any()).Return(nil)
 	mockGit.EXPECT().CreateWorktree(params.RepoPath, params.WorktreePath, params.Branch).Return(nil)
@@ -220,6 +221,7 @@ func TestWorktree_Create_BranchDoesNotExist(t *testing.T) {
 	mockFS.EXPECT().Exists(params.WorktreePath).Return(false, nil)
 	mockStatus.EXPECT().GetWorktree(params.RepoURL, params.Branch).Return(nil, errors.New("not found"))
 	mockFS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil)
+	mockGit.EXPECT().CheckReferenceConflict(params.RepoPath, params.Branch).Return(nil)
 	mockGit.EXPECT().BranchExists(params.RepoPath, params.Branch).Return(false, nil)
 	mockGit.EXPECT().GetRemoteURL(params.RepoPath, "origin").Return("https://github.com/octocat/Hello-World.git", nil)
 	mockGit.EXPECT().GetDefaultBranch("https://github.com/octocat/Hello-World.git").Return("main", nil)
@@ -496,6 +498,7 @@ func TestWorktree_EnsureBranchExists_BranchExists(t *testing.T) {
 	branch := "feature-branch"
 
 	// Mock expectations
+	mockGit.EXPECT().CheckReferenceConflict(repoPath, branch).Return(nil)
 	mockGit.EXPECT().BranchExists(repoPath, branch).Return(true, nil)
 
 	err := worktree.EnsureBranchExists(repoPath, branch)
@@ -526,6 +529,7 @@ func TestWorktree_EnsureBranchExists_BranchDoesNotExist(t *testing.T) {
 	branch := "feature-branch"
 
 	// Mock expectations
+	mockGit.EXPECT().CheckReferenceConflict(repoPath, branch).Return(nil)
 	mockGit.EXPECT().BranchExists(repoPath, branch).Return(false, nil)
 	mockGit.EXPECT().GetRemoteURL(repoPath, "origin").Return("https://github.com/octocat/Hello-World.git", nil)
 	mockGit.EXPECT().GetDefaultBranch("https://github.com/octocat/Hello-World.git").Return("main", nil)


### PR DESCRIPTION
- Added CheckReferenceConflict method to Git interface to detect reference conflicts
- Added ErrReferenceConflict error type for specific error handling
- Updated EnsureBranchExists to check for conflicts before creating branches
- Added comprehensive integration tests for reference conflict scenarios
- Fixed Git user configuration in test setup for Docker container compatibility
- Updated unit tests to include new CheckReferenceConflict mock expectations
- Regenerated mocks to include new interface method

This fix prevents the cryptic Git error when trying to create branches that conflict with existing references (e.g., feat/test when feat already exists). Users now get clear error messages explaining the conflict.