### PR TITLE
ci: add release on GitHub for multiple architectures

### DIFF
--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -6,8 +6,8 @@ import (
 	"slices"
 )
 
-// RunnerInfo represents a Docker runner.
-type RunnerInfo struct {
+// ImageInfo represents a Docker image.
+type ImageInfo struct {
 	OS              string
 	Arch            string
 	BuildBaseImage  string
@@ -15,8 +15,8 @@ type RunnerInfo struct {
 }
 
 var (
-	// GoRunnersInfo represents the different OS/Arch platform wanted for docker hub in Go service.
-	GoRunnersInfo = map[string]RunnerInfo{
+	// GoImageInfo represents the different OS/Arch platform wanted for binaries.
+	GoImageInfo = map[string]ImageInfo{
 		"linux/386":      {OS: "linux", Arch: "386", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
 		"linux/amd64":    {OS: "linux", Arch: "amd64", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
 		"linux/arm/v6":   {OS: "linux", Arch: "arm/v6", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
@@ -29,13 +29,13 @@ var (
 )
 
 func AvailablePlatforms() []string {
-	return slices.Collect(maps.Keys(GoRunnersInfo))
+	return slices.Collect(maps.Keys(GoImageInfo))
 }
 
-// Runner returns a container running the code-manager
-func Runner(
+// Image returns a container running the code-manager
+func Image(
 	sourceDir *dagger.Directory,
-	runnerInfo RunnerInfo,
+	runnerInfo ImageInfo,
 ) *dagger.Container {
 	return sourceDir.DockerBuild(dagger.DirectoryDockerBuildOpts{
 		BuildArgs: []dagger.BuildArg{

--- a/.dagger/runner.go
+++ b/.dagger/runner.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"code-manager/dagger/internal/dagger"
+	"maps"
+	"slices"
+)
+
+// RunnerInfo represents a Docker runner.
+type RunnerInfo struct {
+	OS              string
+	Arch            string
+	BuildBaseImage  string
+	TargetBaseImage string
+}
+
+var (
+	// GoRunnersInfo represents the different OS/Arch platform wanted for docker hub in Go service.
+	GoRunnersInfo = map[string]RunnerInfo{
+		"linux/386":      {OS: "linux", Arch: "386", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/amd64":    {OS: "linux", Arch: "amd64", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/arm/v6":   {OS: "linux", Arch: "arm/v6", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/arm/v7":   {OS: "linux", Arch: "arm/v7", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/arm64/v8": {OS: "linux", Arch: "arm64/v8", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/ppc64le":  {OS: "linux", Arch: "ppc64le", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/riscv64":  {OS: "linux", Arch: "riscv64", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+		"linux/s390x":    {OS: "linux", Arch: "s390x", BuildBaseImage: "golang:alpine", TargetBaseImage: "alpine"},
+	}
+)
+
+func AvailablePlatforms() []string {
+	return slices.Collect(maps.Keys(GoRunnersInfo))
+}
+
+// Runner returns a container running the code-manager
+func Runner(
+	sourceDir *dagger.Directory,
+	runnerInfo RunnerInfo,
+) *dagger.Container {
+	return sourceDir.DockerBuild(dagger.DirectoryDockerBuildOpts{
+		BuildArgs: []dagger.BuildArg{
+			{Name: "BUILDPLATFORM", Value: runnerInfo.OS + "/" + runnerInfo.Arch},
+			{Name: "TARGETOS", Value: runnerInfo.OS},
+			{Name: "TARGETARCH", Value: runnerInfo.Arch},
+			{Name: "BUILDBASEIMAGE", Value: runnerInfo.BuildBaseImage},
+			{Name: "TARGETBASEIMAGE", Value: runnerInfo.TargetBaseImage},
+		},
+		Platform:   dagger.Platform(runnerInfo.OS + "/" + runnerInfo.Arch),
+		Dockerfile: "build/container/Dockerfile",
+	})
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,3 +88,54 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-push-docker-images:
+    name: Build and push Docker images
+    needs: ["publish-tag"]
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          version: latest
+          verb: call
+          args: >-
+            build-and-push-docker-images
+            --source-dir=.
+            --user=env:GITHUB_ACTOR
+            --token=env:GITHUB_TOKEN
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create-github-release:
+    name: Create GitHub release with binaries
+    needs: ["publish-tag"]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          version: latest
+          verb: call
+          args: >-
+            create-github-release
+            --source-dir=.
+            --user=env:GITHUB_ACTOR
+            --token=env:GITHUB_TOKEN
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile arguments
+ARG BUILDPLATFORM=linux/amd64
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+ARG BUILDBASEIMAGE=golang:alpine
+ARG TARGETBASEIMAGE=alpine:latest
+
+# Building Golang image
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ${BUILDBASEIMAGE} AS build
+
+# Get all remaining code
+RUN mkdir -p /go/src/github.com/lerenn/code-manager
+COPY ./ /go/src/github.com/lerenn/code-manager
+
+# Set the workdir
+WORKDIR /go/src/github.com/lerenn/code-manager
+
+# Build everything in cmd/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install ./cmd/*
+
+# Get final base image
+FROM --platform=${TARGETOS}/${TARGETARCH} ${TARGETBASEIMAGE} AS final
+
+# Get binary
+COPY --from=build /go/bin/* /usr/local/bin
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/code-manager"]


### PR DESCRIPTION
This commit implements a comprehensive CI/CD pipeline for building and releasing the CM tool across multiple architectures on GitHub.

Key changes:
- Enhanced .dagger/main.go with 140+ lines of new functionality for multi-arch builds
- Added .dagger/runner.go (51 lines) for containerized build execution
- Updated .github/workflows/ci.yaml (51 lines) with GitHub Actions workflow
- Created build/container/Dockerfile (32 lines) for containerized builds

The implementation supports cross-platform compilation and automated releases through GitHub Actions, enabling distribution of CM binaries for multiple operating systems and architectures.