### PR TITLE
fix: resolve CI binary generation and Windows filesystem compatibility

### DIFF
--- a/.dagger/github.go
+++ b/.dagger/github.go
@@ -223,8 +223,8 @@ func (gh *GitHubReleaseManager) uploadBinary(
 	}
 
 	// Get the binary file content from the build container
-	// The binary is built in /go/bin/cm in the build stage
-	binaryPath := "/go/bin/cm"
+	// The binary is built in /go/bin/{GOOS}_{GOARCH}/cm for cross-compilation
+	binaryPath := fmt.Sprintf("/go/bin/%s_%s/cm", runnerInfo.OS, runnerInfo.Arch)
 	binaryContent, err := container.File(binaryPath).Contents(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to read binary file at %s: %w", binaryPath, err)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -135,7 +135,10 @@ func (ci *CodeManager) BuildForArchitecture(
 	}
 
 	// Build binary for this architecture
-	container := BuildImage(sourceDir, runnerInfo)
+	container, err := BuildImage(sourceDir, runnerInfo)
+	if err != nil {
+		return nil, err
+	}
 
 	return container, nil
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,38 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-and-release-linux-arm64:
+    name: Build and release for linux/arm64
+    needs: ["publish-tag"]
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          version: latest
+          verb: call
+          args: >-
+            build-and-release-for-architecture
+            --source-dir=.
+            --architecture=linux/arm64
+            --user=${{ github.actor }}
+            --token=env:GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-release-darwin-arm64:
     name: Build and release for darwin/arm64
     needs: ["publish-tag"]

--- a/build/container/Dockerfile.build
+++ b/build/container/Dockerfile.build
@@ -1,10 +1,12 @@
 # Dockerfile.build - Build stage for cross-compilation
-# Dockerfile arguments
+# Build argument for the base image - must be declared before FROM
+ARG BUILDBASEIMAGE=golang:alpine
+
+FROM ${BUILDBASEIMAGE} AS build
+
+# Build arguments for cross-compilation
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-
-# Building Golang image
-FROM golang:alpine AS build
 
 # Get all remaining code
 RUN mkdir -p /go/src/github.com/lerenn/code-manager

--- a/build/container/Dockerfile.runtime
+++ b/build/container/Dockerfile.runtime
@@ -1,7 +1,10 @@
 # Dockerfile.runtime - Runtime stage for running the application
-# This Dockerfile expects a build stage with the binary at /go/bin/cm
+# This Dockerfile expects a build stage with the binary at /go/bin/{GOOS}_{GOARCH}/cm
 
-FROM alpine:latest
+# Build argument for the target base image
+ARG TARGETBASEIMAGE=alpine:latest
+
+FROM ${TARGETBASEIMAGE}
 
 # Copy the binary from the build stage
 COPY --from=build /go/bin/cm /usr/local/bin/cm

--- a/pkg/fs/fs_unix.go
+++ b/pkg/fs/fs_unix.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// FileLock acquires a file lock and returns an unlock function.
+// This implementation uses syscall.Flock which is available on Unix systems.
+func (f *realFS) FileLock(filename string) (func(), error) {
+	// Create lock file path
+	lockPath := filename + ".lock"
+
+	// Ensure parent directory exists before creating lock file
+	lockDir := filepath.Dir(lockPath)
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		return nil, err
+	}
+
+	// Create lock file
+	lockFile, err := os.Create(lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Acquire file lock (non-blocking)
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if closeErr := lockFile.Close(); closeErr != nil {
+			// Log the error but don't fail for cleanup errors
+			_ = closeErr
+		}
+		if removeErr := os.Remove(lockPath); removeErr != nil {
+			// Log the error but don't fail for cleanup errors
+			_ = removeErr
+		}
+		return nil, err
+	}
+
+	// Return unlock function
+	unlock := func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		if closeErr := lockFile.Close(); closeErr != nil {
+			// Log the error but don't fail for cleanup errors
+			_ = closeErr
+		}
+		if removeErr := os.Remove(lockPath); removeErr != nil {
+			// Log the error but don't fail for cleanup errors
+			_ = removeErr
+		}
+	}
+
+	return unlock, nil
+}

--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FileLock acquires a file lock and returns an unlock function.
+// This is a no-op implementation for Windows since flock is not available.
+// On Windows, file locking is typically handled differently and may not be needed
+// for the use cases in this application.
+func (f *realFS) FileLock(filename string) (func(), error) {
+	// Create lock file path
+	lockPath := filename + ".lock"
+
+	// Ensure parent directory exists before creating lock file
+	lockDir := filepath.Dir(lockPath)
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		return nil, err
+	}
+
+	// Create lock file (this serves as a simple indicator that the file is "locked")
+	lockFile, err := os.Create(lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return unlock function that removes the lock file
+	unlock := func() {
+		if closeErr := lockFile.Close(); closeErr != nil {
+			// Log the error but don't fail for cleanup errors
+			_ = closeErr
+		}
+		if removeErr := os.Remove(lockPath); removeErr != nil {
+			// Log the error but don't fail for cleanup errors
+			_ = removeErr
+		}
+	}
+
+	return unlock, nil
+}


### PR DESCRIPTION
This commit fixes two critical issues:

1. CI Binary Generation Issue:
- Fixed cross-compilation where all binaries had identical SHA256 hashes
- Updated Dockerfile.build to properly handle build args and binary paths
- Fixed binary extraction to use correct paths (/go/bin/{GOOS}_{GOARCH}/cm)
- Added linux/arm64 support to CI workflow
- Improved build system architecture with separate build/runtime Dockerfiles

2. Windows Filesystem Compatibility:
- Added cross-platform build tags for FileLock function
- Created pkg/fs/fs_unix.go for Unix systems (uses syscall.Flock)
- Created pkg/fs/fs_windows.go for Windows systems (no-op implementation)
- Removed platform-specific code from main fs.go file
- Windows builds now work correctly without syscall.Flock errors

3. Build System Improvements:
- Split Dockerfiles into build and runtime stages
- Made build system configuration-driven using GoImageInfo map
- Added proper error handling for unsupported build platforms
- Improved platform detection and base image selection
- Removed redundant linux/arm64/v8 platform definition

4. CI Enhancements:
- Added linux/arm64 build and release job
- All platforms now generate correct binary formats:
  - Linux AMD64: ELF binary
  - Linux ARM64: ELF binary
  - Darwin ARM64: Mach-O binary
  - Windows AMD64: PE executable (.exe)

This fix ensures proper cross-platform binary generation and enables Windows compatibility.