### PR TITLE
fix: ensure new worktrees are created from origin default branch

### DIFF
--- a/pkg/workspace/worktree_operations.go
+++ b/pkg/workspace/worktree_operations.go
@@ -209,8 +209,15 @@ func (w *realWorkspace) autoAddRepositoryToStatus(repoURL, repoPath string) erro
 	// Check for origin remote
 	originURL, err := w.git.GetRemoteURL(absPath, "origin")
 	if err == nil && originURL != "" {
+		// Get the actual default branch from the remote repository
+		defaultBranch, err := w.git.GetDefaultBranch(originURL)
+		if err != nil {
+			w.verboseLogf("Warning: failed to get default branch from remote, using 'main' as fallback: %v", err)
+			defaultBranch = "main" // Fallback to main if we can't determine the actual default branch
+		}
+
 		remotes["origin"] = status.Remote{
-			DefaultBranch: "main", // Default to main, could be enhanced to detect actual default branch
+			DefaultBranch: defaultBranch,
 		}
 	}
 

--- a/test/repo_create_test.go
+++ b/test/repo_create_test.go
@@ -4,6 +4,7 @@ package test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -279,6 +280,95 @@ func TestCreateWorktreeWithIDE(t *testing.T) {
 	actualPath, err := filepath.EvalSymlinks(repo.Path)
 	require.NoError(t, err)
 	assert.Equal(t, expectedPath, actualPath, "Path should be the original repository directory, not the worktree directory")
+}
+
+// TestCreateWorktreeFromOriginDefaultBranch tests that new worktrees are created from origin's default branch
+// and not from the local default branch, even when the local branch has been reset to an older commit
+func TestCreateWorktreeFromOriginDefaultBranch(t *testing.T) {
+	setup := setupTestEnvironment(t)
+	defer cleanupTestEnvironment(t, setup)
+
+	// Clone the octocat/Hello-World repository
+	cmInstance, err := cm.NewCM(&config.Config{
+		BasePath:   setup.CmPath,
+		StatusFile: setup.StatusPath,
+	})
+	require.NoError(t, err)
+
+	// Clone the repository
+	err = cmInstance.Clone("https://github.com/octocat/Hello-World.git")
+	require.NoError(t, err, "Repository clone should succeed")
+
+	// Find the cloned repository path
+	status := readStatusFile(t, setup.StatusPath)
+	require.NotNil(t, status.Repositories, "Status file should have repositories section")
+	require.True(t, len(status.Repositories) > 0, "Should have at least one repository")
+
+	var repoPath string
+	for _, repo := range status.Repositories {
+		repoPath = repo.Path
+		break
+	}
+	require.NotEmpty(t, repoPath, "Repository path should be set")
+
+	// Safely change to repo directory
+	restore := safeChdir(t, repoPath)
+	defer restore()
+
+	// Create a dummy commit locally to create a difference between local master and origin/master
+	t.Log("Creating a dummy commit locally to create difference between local and origin")
+	err = createDummyCommit(t, repoPath)
+	require.NoError(t, err, "Should be able to create dummy commit")
+
+	// Now local master is ahead of origin/master
+	// Local: A -> B -> C -> D (dummy)
+	// Origin: A -> B -> C
+	localCommitWithDummy, err := getCurrentCommit(t, repoPath)
+	require.NoError(t, err, "Should be able to get local commit with dummy")
+
+	// Get the commit before the dummy (which should be the same as origin/master)
+	commitBeforeDummy, err := getPreviousCommit(t, repoPath)
+	require.NoError(t, err, "Should be able to get commit before dummy")
+
+	// Verify that local is now ahead of origin
+	assert.NotEqual(t, commitBeforeDummy, localCommitWithDummy, "Local master should be ahead of origin/master")
+
+	// Create a new worktree
+	err = cmInstance.CreateWorkTree("test-origin-default")
+	require.NoError(t, err, "Worktree creation should succeed")
+
+	// Verify the worktree exists
+	assertWorktreeExists(t, setup, "test-origin-default")
+
+	// Get the worktree path
+	worktreePath := filepath.Join(setup.CmPath, "github.com/octocat/Hello-World", "origin", "test-origin-default")
+	require.DirExists(t, worktreePath, "Worktree directory should exist")
+
+	// Check what commit the worktree is on
+	worktreeCommit, err := getCurrentCommit(t, worktreePath)
+	require.NoError(t, err, "Should be able to get worktree commit")
+
+	t.Logf("Worktree commit: %s", worktreeCommit)
+	t.Logf("Local commit with dummy: %s", localCommitWithDummy)
+	t.Logf("Commit before dummy (origin/master): %s", commitBeforeDummy)
+
+	// The worktree creation is working correctly - it's using origin/master instead of local master
+	// This verifies that our primary mechanism is working: new worktrees are created from origin's default branch
+	assert.Equal(t, commitBeforeDummy, worktreeCommit, "Worktree should be on origin/master (commit before dummy)")
+
+	// The worktree should NOT be on the commit with the dummy because it's using origin/master, not local master
+	assert.NotEqual(t, localCommitWithDummy, worktreeCommit, "Worktree should not be on the commit with dummy when using origin/master")
+
+	// Verify the worktree is properly linked in the cloned repository
+	// We need to check from the cloned repo path, not the original test repo path
+	cmd := exec.Command("git", "worktree", "list")
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	require.NoError(t, err, "Should be able to list worktrees")
+
+	// The worktree should be listed in the cloned repository
+	assert.Contains(t, string(output), "test-origin-default", "Worktree should be listed in the cloned repository")
+	assert.Contains(t, string(output), setup.CmPath, "Worktree should be in the .cm directory")
 }
 
 // TestCreateWorktreeWithUnsupportedIDE tests creating a worktree with unsupported IDE


### PR DESCRIPTION
- Updated createBranchFromDefaultBranch to always use origin's actual default branch
- Added fallback behavior: if no remote, fallback to local default branch; if no default branch, fallback to current branch
- Enhanced workspace worktree operations to detect actual default branch from remote
- Updated unit tests to reflect new remote-first behavior
- Added comprehensive E2E test TestCreateWorktreeFromOriginDefaultBranch
- Added helper functions for Git operations in tests
- Refactored test code to use switch case for better readability

This ensures that new worktrees are always created from the most up-to-date origin default branch while maintaining robustness through intelligent fallbacks.

Closes #88 